### PR TITLE
fix: Moved `SuperTokensTokenTransferMethod` for cleaner imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2] - 2023-03-17
+
+### Fixes
+- Moved `SuperTokensTokenTransferMethod` from utilities to supertokens for cleaner imports
+
 ## [0.2.1] - 2023-03-16
 
 - Fixes an issues that caused reference documentaiotn regeneration to fail

--- a/lib/src/supertokens.dart
+++ b/lib/src/supertokens.dart
@@ -15,6 +15,19 @@ enum Eventype {
 
 enum APIAction { SIGN_OUT, REFRESH_TOKEN }
 
+enum SuperTokensTokenTransferMethod { COOKIE, HEADER }
+
+extension ValueExtension on SuperTokensTokenTransferMethod {
+  String getValue() {
+    switch (this) {
+      case SuperTokensTokenTransferMethod.HEADER:
+        return "header";
+      case SuperTokensTokenTransferMethod.COOKIE:
+        return "cookie";
+    }
+  }
+}
+
 /// Primary class for the supertokens package
 /// Use [SuperTokens.initialise] to initialise the package, do this before making any network calls
 class SuperTokens {

--- a/lib/src/utilities.dart
+++ b/lib/src/utilities.dart
@@ -24,19 +24,6 @@ extension TokenTypeExtension on TokenType {
   }
 }
 
-enum SuperTokensTokenTransferMethod { COOKIE, HEADER }
-
-extension ValueExtension on SuperTokensTokenTransferMethod {
-  String getValue() {
-    switch (this) {
-      case SuperTokensTokenTransferMethod.HEADER:
-        return "header";
-      case SuperTokensTokenTransferMethod.COOKIE:
-        return "cookie";
-    }
-  }
-}
-
 class LocalSessionState {
   LocalSessionStateStatus status;
   String? lastAccessTokenUpdate;

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,4 +1,4 @@
 class Version {
   static List<String> supported_fdi = ["1.16"];
-  static String sdkVersion = "0.2.1";
+  static String sdkVersion = "0.2.2";
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: supertokens_flutter
 description: SuperTokens SDK for Flutter apps
-version: 0.2.1
+version: 0.2.2
 homepage: https://supertokens.com/
 repository: https://github.com/supertokens/supertokens-flutter
 issue_tracker: https://github.com/supertokens/supertokens-flutter/issues


### PR DESCRIPTION
## Summary of change
Moved `SuperTokensTokenTransferMethod` from utilities to supertokens

## Related issues

## Test Plan
All existing tests pass

## Documentation changes


## Checklist for important updates
- [x] Changelog has been updated
- [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
   - Along with the associated array in `lib/src/version.dart`
- [x] Changes to the version if needed
   - In `pubspec.yaml`
   - In `lib/src/version.dart`
- [x] Had installed and ran the pre-commit hook
- [x] Issue this PR against the latest non released version branch.
   - To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
   - If no such branch exists, then create one from the latest released branch.

## Remaining TODOs for this PR