### PR TITLE
fix: Fix interception logic for auth headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.5] - 2023-07-10
+
+### Fixes
+
+- Fixed an issue where the Authorization header was getting removed unnecessarily
+
 ## [0.2.4] - 2023-06-08
 
 - Refactors session logic to delete access token and refresh token if the front token is removed. This helps with proxies that strip headers with empty values which would result in the access token and refresh token to persist after signout

--- a/lib/src/dio-interceptor-wrapper.dart
+++ b/lib/src/dio-interceptor-wrapper.dart
@@ -209,8 +209,9 @@ class SuperTokensInterceptorWrapper extends Interceptor {
         authValue = req.headers["authorization"];
       }
       String? accessToken = await Utils.getTokenForHeaderAuth(TokenType.ACCESS);
+      String? refreshToken = await Utils.getTokenForHeaderAuth(TokenType.REFRESH);
 
-      if (accessToken != null && authValue != "Bearer $accessToken") {
+      if (accessToken != null && refreshToken != null && authValue != "Bearer $accessToken") {
         req.headers.remove('Authorization');
         req.headers.remove('authorization');
       }

--- a/lib/src/supertokens-http-client.dart
+++ b/lib/src/supertokens-http-client.dart
@@ -162,8 +162,9 @@ class Client extends http.BaseClient {
         authValue = mutableRequest.headers["authorization"];
       }
       String? accessToken = await Utils.getTokenForHeaderAuth(TokenType.ACCESS);
+      String? refreshToken = await Utils.getTokenForHeaderAuth(TokenType.REFRESH);
 
-      if (accessToken != null && authValue == "Bearer $accessToken") {
+      if (accessToken != null && refreshToken != null && authValue == "Bearer $accessToken") {
         mutableRequest.headers.remove("Authorization");
         mutableRequest.headers.remove("authorization");
       }

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,4 +1,4 @@
 class Version {
   static List<String> supported_fdi = ["1.16"];
-  static String sdkVersion = "0.2.4";
+  static String sdkVersion = "0.2.5";
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: supertokens_flutter
 description: SuperTokens SDK for Flutter apps
-version: 0.2.4
+version: 0.2.5
 homepage: https://supertokens.com/
 repository: https://github.com/supertokens/supertokens-flutter
 issue_tracker: https://github.com/supertokens/supertokens-flutter/issues

--- a/test/dioInterceptor_test.dart
+++ b/test/dioInterceptor_test.dart
@@ -431,4 +431,24 @@ void main() {
     var loginResp = await dio.fetch(req);
     if (loginResp.statusCode != 200) fail("Login req failed");
   });
+
+  test("should not ignore the auth header even if it matches the stored access token", () async {
+    await SuperTokensTestUtils.startST();
+    SuperTokens.init(apiDomain: apiBasePath);
+
+    RequestOptions req = SuperTokensTestUtils.getLoginRequestDio();
+    Dio dio = setUpDio();
+    var resp = await dio.fetch(req);
+    if (resp.statusCode != 200) fail("Login req failed");
+
+    await Future.delayed(Duration(seconds: 5), () {});
+
+    Utils.setToken(TokenType.ACCESS, "myOwnHeHe");
+
+    dio.options.headers['Authorization'] = "Bearer myOwnHeHe";
+    var userInfoResp = await dio.get("/base-custom-auth");
+    if (userInfoResp.statusCode != 200) {
+      fail("User Info API failed");
+    }
+  });
 }

--- a/test/supertokens_test.dart
+++ b/test/supertokens_test.dart
@@ -416,4 +416,29 @@ void main() {
     assert(accessTokenAfter == null);
     assert(refreshTokenAfter == null);
   });
+
+  test("should not ignore the auth header even if it matches the stored access token", () async {
+    await SuperTokensTestUtils.startST();
+    SuperTokens.init(apiDomain: apiBasePath);
+
+    Request req = SuperTokensTestUtils.getLoginRequest();
+    StreamedResponse streamedResp;
+    streamedResp = await http.send(req);
+    var loginResp = await Response.fromStream(streamedResp);
+    if (loginResp.statusCode != 200) {
+      fail("Login failed");
+    }
+
+    await Future.delayed(Duration(seconds: 5), () {});
+
+    Utils.setToken(TokenType.ACCESS, "myOwnHeHe");
+
+    Uri url = Uri.parse("$apiBasePath/base-custom-auth");
+    var resp = await http.get(url, headers: {
+      "Authorization": "Bearer myOwnHeHe",
+    });
+    if (resp.statusCode != 200) {
+      fail("User info get API failed");
+    }
+  });
 }

--- a/testHelpers/server/index.js
+++ b/testHelpers/server/index.js
@@ -525,6 +525,15 @@ app.post("/logout-alt", async (req, res) => {
         .json({});
 });
 
+app.get("/base-custom-auth", async (req, res) => {
+    let header = req.headers["authorization"];
+    if (header === "Bearer myOwnHeHe") {
+        return res.status(200).json({message: "OK"});
+    } else {
+        return res.status(500).json({message: "Bad auth header"});
+    }
+})
+
 app.use("*", async (req, res, next) => {
     res.status(404).send();
 });


### PR DESCRIPTION
## Summary of change
Changes interception logic when adding the authorisation bearer token in the headers

## Related issues
- 

## Test Plan
Adds new tests

## Documentation changes
NA

## Checklist for important updates
- [x] Changelog has been updated
- [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
   - Along with the associated array in `lib/src/version.dart`
- [x] Changes to the version if needed
   - In `pubspec.yaml`
   - In `lib/src/version.dart`
- [x] Had installed and ran the pre-commit hook
- [x] Issue this PR against the latest non released version branch.
   - To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
   - If no such branch exists, then create one from the latest released branch.

## Remaining TODOs for this PR
- [ ] ...