### PR TITLE
fix: session refresh loop in all request interceptors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2024-06-05
+
+### Changes
+
+- Fixed the session refresh loop in all the request interceptors that occurred when an API returned a 401 response despite a valid session. Interceptors now attempt to refresh the session a maximum of ten times before throwing an error. The retry limit is configurable via the `maxRetryAttemptsForSessionRefresh` option.
+
 ## [0.5.1] - 2024-05-28
 
 - Adds FDI 2.0 and 3.0 to the list of supported versions

--- a/lib/src/supertokens.dart
+++ b/lib/src/supertokens.dart
@@ -41,6 +41,7 @@ class SuperTokens {
   static void init({
     required String apiDomain,
     String? apiBasePath,
+    int? maxRetryAttemptsForSessionRefresh,
     int sessionExpiredStatusCode = 401,
     String? sessionTokenBackendDomain,
     SuperTokensTokenTransferMethod? tokenTransferMethod,
@@ -56,6 +57,7 @@ class SuperTokens {
       apiDomain,
       apiBasePath,
       sessionExpiredStatusCode,
+      maxRetryAttemptsForSessionRefresh,
       sessionTokenBackendDomain,
       tokenTransferMethod,
       eventHandler,

--- a/lib/src/utilities.dart
+++ b/lib/src/utilities.dart
@@ -367,15 +367,19 @@ class NormalisedInputType {
     var _apiDOmain = NormalisedURLDomain(apiDomain);
     var _apiBasePath = NormalisedURLPath("/auth");
 
-    if (apiBasePath != null) _apiBasePath = NormalisedURLPath(apiBasePath);
+    if (apiBasePath != null) {
+      _apiBasePath = NormalisedURLPath(apiBasePath);
+    }
 
     var _sessionExpiredStatusCode = 401;
-    if (sessionExpiredStatusCode != null)
+    if (sessionExpiredStatusCode != null) {
       _sessionExpiredStatusCode = sessionExpiredStatusCode;
+    }
 
     var _maxRetryAttemptsForSessionRefresh = 10;
-    if (maxRetryAttemptsForSessionRefresh != null)
+    if (maxRetryAttemptsForSessionRefresh != null) {
       _maxRetryAttemptsForSessionRefresh = maxRetryAttemptsForSessionRefresh;
+    }
 
     String? _sessionTokenBackendDomain = null;
     if (sessionTokenBackendDomain != null) {
@@ -390,15 +394,21 @@ class NormalisedInputType {
     }
 
     Function(Eventype)? _eventHandler = (_) => {};
-    if (eventHandler != null) _eventHandler = eventHandler;
+    if (eventHandler != null) {
+      _eventHandler = eventHandler;
+    }
 
     http.Request Function(APIAction, http.Request)? _preAPIHook =
         (_, request) => request;
-    if (preAPIHook != null) _preAPIHook = preAPIHook;
+    if (preAPIHook != null) {
+      _preAPIHook = preAPIHook;
+    }
 
     Function(APIAction, http.Request, http.Response) _postAPIHook =
         (_, __, ___) => null;
-    if (postAPIHook != null) _postAPIHook = postAPIHook;
+    if (postAPIHook != null) {
+      _postAPIHook = postAPIHook;
+    }
 
     return NormalisedInputType(
         _apiDOmain.value,

--- a/lib/src/utilities.dart
+++ b/lib/src/utilities.dart
@@ -317,6 +317,7 @@ class NormalisedInputType {
   late String apiDomain;
   late String? apiBasePath;
   late int sessionExpiredStatusCode = 401;
+  late int maxRetryAttemptsForSessionRefresh = 10;
   late String? sessionTokenBackendDomain;
   late SuperTokensTokenTransferMethod tokenTransferMethod;
   late String? userDefaultSuiteName;
@@ -328,6 +329,13 @@ class NormalisedInputType {
     String apiDomain,
     String? apiBasePath,
     int sessionExpiredStatusCode,
+    /**
+     * This specifies the maximum number of times the interceptor will attempt to refresh
+     * the session  when a 401 Unauthorized response is received. If the number of retries
+     * exceeds this limit, no further attempts will be made to refresh the session, and
+     * and an error will be thrown.
+     */
+    int maxRetryAttemptsForSessionRefresh,
     String? sessionTokenBackendDomain,
     SuperTokensTokenTransferMethod tokenTransferMethod,
     Function(Eventype)? eventHandler,
@@ -337,6 +345,7 @@ class NormalisedInputType {
     this.apiDomain = apiDomain;
     this.apiBasePath = apiBasePath;
     this.sessionExpiredStatusCode = sessionExpiredStatusCode;
+    this.maxRetryAttemptsForSessionRefresh = maxRetryAttemptsForSessionRefresh;
     this.sessionTokenBackendDomain = sessionTokenBackendDomain;
     this.tokenTransferMethod = tokenTransferMethod;
     this.eventHandler = eventHandler!;
@@ -348,6 +357,7 @@ class NormalisedInputType {
     String apiDomain,
     String? apiBasePath,
     int? sessionExpiredStatusCode,
+    int? maxRetryAttemptsForSessionRefresh,
     String? sessionTokenBackendDomain,
     SuperTokensTokenTransferMethod? tokenTransferMethod,
     Function(Eventype)? eventHandler,
@@ -362,6 +372,10 @@ class NormalisedInputType {
     var _sessionExpiredStatusCode = 401;
     if (sessionExpiredStatusCode != null)
       _sessionExpiredStatusCode = sessionExpiredStatusCode;
+
+    var _maxRetryAttemptsForSessionRefresh = 10;
+    if (maxRetryAttemptsForSessionRefresh != null)
+      _maxRetryAttemptsForSessionRefresh = maxRetryAttemptsForSessionRefresh;
 
     String? _sessionTokenBackendDomain = null;
     if (sessionTokenBackendDomain != null) {
@@ -390,6 +404,7 @@ class NormalisedInputType {
         _apiDOmain.value,
         _apiBasePath.value,
         _sessionExpiredStatusCode,
+        _maxRetryAttemptsForSessionRefresh,
         _sessionTokenBackendDomain,
         _tokenTransferMethod,
         _eventHandler,

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -7,5 +7,5 @@ class Version {
     "2.0",
     "3.0"
   ];
-  static String sdkVersion = "0.5.1";
+  static String sdkVersion = "0.6.0";
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -553,10 +553,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: e7d5ecd604e499358c5fe35ee828c0298a320d54455e791e9dcf73486bc8d9f0
+      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
       url: "https://pub.dev"
     source: hosted
-    version: "14.1.0"
+    version: "14.2.1"
   watcher:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: supertokens_flutter
 description: SuperTokens SDK for Flutter apps
-version: 0.5.1
+version: 0.6.0
 homepage: https://supertokens.com/
 repository: https://github.com/supertokens/supertokens-flutter
 issue_tracker: https://github.com/supertokens/supertokens-flutter/issues

--- a/test/dioInterceptor_test.dart
+++ b/test/dioInterceptor_test.dart
@@ -451,4 +451,85 @@ void main() {
       fail("User Info API failed");
     }
   });
+
+  test(
+      "should break out of session refresh loop after default maxRetryAttemptsForSessionRefresh value",
+      () async {
+    await SuperTokensTestUtils.startST();
+    SuperTokens.init(
+        apiDomain: apiBasePath);
+
+    RequestOptions req = SuperTokensTestUtils.getLoginRequestDio();
+    Dio dio = setUpDio();
+    var resp = await dio.fetch(req);
+    assert(resp.statusCode == 200, "Login req failed");
+
+    assert(await SuperTokensTestUtils.refreshTokenCounter() == 0,
+        "refresh token count should have been 0");
+
+    try {
+      await dio.get("/throw-401");
+      fail("Expected the request to throw an error");
+    } on DioException catch (err) {
+      assert(err.error.toString() ==
+          "Received a 401 response from http://localhost:8080/throw-401. Attempted to refresh the session and retry the request with the updated session tokens 10 times, but each attempt resulted in a 401 error. The maximum session refresh limit has been reached. Please investigate your API. To increase the session refresh attempts, update maxRetryAttemptsForSessionRefresh in the config.");
+    }
+
+    assert(await SuperTokensTestUtils.refreshTokenCounter() == 10,
+        "session refresh endpoint should have been called 10 times");
+  });
+
+  test(
+      "should break out of session refresh loop after configured maxRetryAttemptsForSessionRefresh value",
+      () async {
+    await SuperTokensTestUtils.startST();
+    SuperTokens.init(
+        apiDomain: apiBasePath, maxRetryAttemptsForSessionRefresh: 5);
+
+    RequestOptions req = SuperTokensTestUtils.getLoginRequestDio();
+    Dio dio = setUpDio();
+    var resp = await dio.fetch(req);
+    assert(resp.statusCode == 200, "Login req failed");
+
+    assert(await SuperTokensTestUtils.refreshTokenCounter() == 0,
+        "refresh token count should have been 0");
+
+    try {
+      await dio.get("/throw-401");
+      fail("Expected the request to throw an error");
+    } on DioException catch (err) {
+      assert(err.error.toString() ==
+          "Received a 401 response from http://localhost:8080/throw-401. Attempted to refresh the session and retry the request with the updated session tokens 5 times, but each attempt resulted in a 401 error. The maximum session refresh limit has been reached. Please investigate your API. To increase the session refresh attempts, update maxRetryAttemptsForSessionRefresh in the config.");
+    }
+
+    assert(await SuperTokensTestUtils.refreshTokenCounter() == 5,
+        "session refresh endpoint should have been called 5 times");
+  });
+
+  test(
+      "should not do session refresh if maxRetryAttemptsForSessionRefresh is 0",
+      () async {
+    await SuperTokensTestUtils.startST();
+    SuperTokens.init(
+        apiDomain: apiBasePath, maxRetryAttemptsForSessionRefresh: 0);
+
+    RequestOptions req = SuperTokensTestUtils.getLoginRequestDio();
+    Dio dio = setUpDio();
+    var resp = await dio.fetch(req);
+    assert(resp.statusCode == 200, "Login req failed");
+
+    assert(await SuperTokensTestUtils.refreshTokenCounter() == 0,
+        "refresh token count should have been 0");
+
+    try {
+      await dio.get("/throw-401");
+      fail("Expected the request to throw an error");
+    } on DioException catch (err) {
+      assert(err.error.toString() ==
+          "Received a 401 response from http://localhost:8080/throw-401. Attempted to refresh the session and retry the request with the updated session tokens 0 times, but each attempt resulted in a 401 error. The maximum session refresh limit has been reached. Please investigate your API. To increase the session refresh attempts, update maxRetryAttemptsForSessionRefresh in the config.");
+    }
+
+    assert(await SuperTokensTestUtils.refreshTokenCounter() == 0,
+        "session refresh endpoint should have been called 0 times");
+  });
 }

--- a/test/http_interceptor_test.dart
+++ b/test/http_interceptor_test.dart
@@ -1,0 +1,106 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:supertokens_flutter/http.dart' as http;
+import 'package:supertokens_flutter/supertokens.dart';
+
+import 'test-utils.dart';
+
+void main() {
+  String apiBasePath = SuperTokensTestUtils.baseUrl;
+
+  setUpAll(() async {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    await SuperTokensTestUtils.beforeAllTest();
+  });
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await SuperTokensTestUtils.beforeEachTest();
+    SuperTokens.isInitCalled = false;
+    await Future.delayed(Duration(seconds: 1), () {});
+  });
+
+  tearDownAll(() async => await SuperTokensTestUtils.afterAllTest());
+
+  test(
+      "should break out of session refresh loop after default maxRetryAttemptsForSessionRefresh value",
+      () async {
+    await SuperTokensTestUtils.startST();
+    SuperTokens.init(apiDomain: apiBasePath);
+
+    Uri uri = Uri.parse("$apiBasePath/login");
+    var loginRes =
+        await http.post(uri, body: {"userId": "supertokens-ios-tests"});
+
+    assert(loginRes.statusCode == 200, "Login req failed");
+
+    assert(await SuperTokensTestUtils.refreshTokenCounter() == 0,
+        "refresh token count should have been 0");
+
+    try {
+      await http.get(Uri.parse("$apiBasePath/throw-401"));
+      fail("Expected the request to throw an error");
+    } on SuperTokensException catch (err) {
+      assert(err.toString() ==
+          "Received a 401 response from http://localhost:8080/throw-401. Attempted to refresh the session and retry the request with the updated session tokens 10 times, but each attempt resulted in a 401 error. The maximum session refresh limit has been reached. Please investigate your API. To increase the session refresh attempts, update maxRetryAttemptsForSessionRefresh in the config.");
+    }
+
+    assert(await SuperTokensTestUtils.refreshTokenCounter() == 10,
+        "session refresh endpoint should have been called 10 times");
+  });
+  test(
+      "should break out of session refresh loop after configured maxRetryAttemptsForSessionRefresh value",
+      () async {
+    await SuperTokensTestUtils.startST();
+    SuperTokens.init(
+        apiDomain: apiBasePath, maxRetryAttemptsForSessionRefresh: 5);
+
+    Uri uri = Uri.parse("$apiBasePath/login");
+    var loginRes =
+        await http.post(uri, body: {"userId": "supertokens-ios-tests"});
+
+    assert(loginRes.statusCode == 200, "Login req failed");
+
+    assert(await SuperTokensTestUtils.refreshTokenCounter() == 0,
+        "refresh token count should have been 0");
+
+    try {
+      await http.get(Uri.parse("$apiBasePath/throw-401"));
+      fail("Expected the request to throw an error");
+    } on SuperTokensException catch (err) {
+      assert(err.toString() ==
+          "Received a 401 response from http://localhost:8080/throw-401. Attempted to refresh the session and retry the request with the updated session tokens 5 times, but each attempt resulted in a 401 error. The maximum session refresh limit has been reached. Please investigate your API. To increase the session refresh attempts, update maxRetryAttemptsForSessionRefresh in the config.");
+    }
+
+    assert(await SuperTokensTestUtils.refreshTokenCounter() == 5,
+        "session refresh endpoint should have been called 5 times");
+  });
+
+  test(
+      "should not do session refresh if maxRetryAttemptsForSessionRefresh is 0",
+      () async {
+    await SuperTokensTestUtils.startST();
+    SuperTokens.init(
+        apiDomain: apiBasePath, maxRetryAttemptsForSessionRefresh: 0);
+
+    Uri uri = Uri.parse("$apiBasePath/login");
+    var loginRes =
+        await http.post(uri, body: {"userId": "supertokens-ios-tests"});
+
+    assert(loginRes.statusCode == 200, "Login req failed");
+
+    assert(await SuperTokensTestUtils.refreshTokenCounter() == 0,
+        "refresh token count should have been 0");
+
+    try {
+      await http.get(Uri.parse("$apiBasePath/throw-401"));
+      fail("Expected the request to throw an error");
+    } on SuperTokensException catch (err) {
+      assert(err.toString() ==
+          "Received a 401 response from http://localhost:8080/throw-401. Attempted to refresh the session and retry the request with the updated session tokens 0 times, but each attempt resulted in a 401 error. The maximum session refresh limit has been reached. Please investigate your API. To increase the session refresh attempts, update maxRetryAttemptsForSessionRefresh in the config.");
+    }
+
+    assert(await SuperTokensTestUtils.refreshTokenCounter() == 0,
+        "session refresh endpoint should have been called 0 times");
+  });
+}

--- a/testHelpers/server/index.js
+++ b/testHelpers/server/index.js
@@ -499,6 +499,10 @@ app.get("/testError", (req, res) => {
     res.status(500).send("test error message");
 });
 
+app.get("/throw-401", (req, res) => {
+    res.status(401).send("Unauthorised");
+});
+
 app.get("/stop", async (req, res) => {
     process.exit();
 });


### PR DESCRIPTION
## Summary of change

This PR fixes the session refresh loop in all the request interceptors that occurred when an API returned a 401 response despite a valid session. Interceptors now attempt to refresh the session a maximum of ten times before returning the last API response. The retry limit is configurable via the `maxRetryAttemptsForSessionRefresh` option.

## Related issues
- Link to issue1 here
- Link to issue1 here

## Test Plan
(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes
(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates
- [x] Changelog has been updated
- [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
   - Along with the associated array in `lib/src/version.dart`
- [x] Changes to the version if needed
   - In `pubspec.yaml`
   - In `lib/src/version.dart`
- [x] Had installed and ran the pre-commit hook
- [x] Issue this PR against the latest non released version branch.
   - To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
   - If no such branch exists, then create one from the latest released branch.