### PR TITLE
fix: remove redundant remove tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1] - 2024-07-12
+
+### Changes
+
+- Removed redundant calls to `removeToken`
+
 ## [0.6.0] - 2024-06-05
 
 ### Changes

--- a/lib/src/dio-interceptor-wrapper.dart
+++ b/lib/src/dio-interceptor-wrapper.dart
@@ -180,13 +180,6 @@ class SuperTokensInterceptorWrapper extends Interceptor {
             type: DioExceptionType.unknown,
             error: e),
       );
-    } finally {
-      LocalSessionState localSessionState =
-          await SuperTokensUtils.getLocalSessionState();
-      if (localSessionState.status == LocalSessionStateStatus.NOT_EXISTS) {
-        await AntiCSRF.removeToken();
-        await FrontToken.removeToken();
-      }
     }
   }
 

--- a/lib/src/front-token.dart
+++ b/lib/src/front-token.dart
@@ -4,6 +4,7 @@ import 'package:mutex/mutex.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:supertokens_flutter/src/utilities.dart';
 import 'package:supertokens_flutter/supertokens.dart';
+import 'package:supertokens_flutter/src/anti-csrf.dart';
 
 class FrontToken {
   static String? tokenInMemory;
@@ -148,6 +149,7 @@ class FrontToken {
     await _removeTokenFromStorage();
     await Utils.setToken(TokenType.ACCESS, "");
     await Utils.setToken(TokenType.REFRESH, "");
+    await AntiCSRF.removeToken()
     if (_tokenInfoMutex.isLocked) {
       _tokenInfoMutex.release();
     }

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -7,5 +7,5 @@ class Version {
     "2.0",
     "3.0"
   ];
-  static String sdkVersion = "0.6.0";
+  static String sdkVersion = "0.6.1";
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: supertokens_flutter
 description: SuperTokens SDK for Flutter apps
-version: 0.6.0
+version: 0.6.1
 homepage: https://supertokens.com/
 repository: https://github.com/supertokens/supertokens-flutter
 issue_tracker: https://github.com/supertokens/supertokens-flutter/issues


### PR DESCRIPTION
## Summary of change

fix: remove redundant removeToken calls

## Related issues
- https://github.com/supertokens/supertokens-website/pull/265
- https://github.com/supertokens/supertokens-react-native/pull/127
- https://github.com/supertokens/supertokens-android/pull/75
- https://github.com/supertokens/supertokens-flutter/pull/61
- https://github.com/supertokens/supertokens-ios/pull/67

## Test Plan
Existing tests should cover this and keep working

## Documentation changes
N/A

## Checklist for important updates
- [x] Changelog has been updated
- [x] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
   - Along with the associated array in `lib/src/version.dart`
- [x] Changes to the version if needed
   - In `pubspec.yaml`
   - In `lib/src/version.dart`
- [x] Had installed and ran the pre-commit hook
- [x] Issue this PR against the latest non released version branch.
   - To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
   - If no such branch exists, then create one from the latest released branch.