### PR TITLE
fix: Failing cookie related tests

### DIFF
--- a/lib/src/cookie-store.dart
+++ b/lib/src/cookie-store.dart
@@ -53,7 +53,7 @@ class SuperTokensCookieStore {
   /// If you are trying to store cookies from a "set-cookie" header response, consider using the [saveFromSetCookieHeader] utility method which parses the header string.
   Future<void> saveFromResponse(Uri uri, List<Cookie> cookies) async {
     logDebugMessage('SuperTokensCookieStore.saveFromResponse: Saving cookies against: ${uri}');
-    logDebugMessage('SuperTokensCookieStore.saveFromResponse: Passed cookies: ${jsonEncode(cookies)}');
+    logDebugMessage('SuperTokensCookieStore.saveFromResponse: Total passed cookies: ${cookies.length}');
     await Future.forEach<Cookie>(cookies, (element) async {
       Uri uriToStore = await _getCookieUri(uri, element);
       logDebugMessage('SuperTokensCookieStore.saveFromResponse: Setting based on uriToStore: ${uriToStore}');


### PR DESCRIPTION
## Summary of change

This fixes failing tests regarding cookies due to a jsonEncode that was being called on a list type of variable that was a side effect of #64 

## Related issues

## Test Plan

Tests should pass

## Documentation changes
(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates
- [ ] Changelog has been updated
- [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
   - Along with the associated array in `lib/src/version.dart`
- [ ] Changes to the version if needed
   - In `pubspec.yaml`
   - In `lib/src/version.dart`
- [x] Had installed and ran the pre-commit hook
- [x] Issue this PR against the latest non released version branch.
   - To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
   - If no such branch exists, then create one from the latest released branch.